### PR TITLE
BDFDB Update

### DIFF
--- a/betterdiscord/supporters.css
+++ b/betterdiscord/supporters.css
@@ -1,17 +1,14 @@
 /* userMacieG#7591 */
-[user_by_bdfdb*="144109479443693568"],
-[data-user-id*="144109479443693568"] {
+[data-user-id="144109479443693568"] {
 	--user-background: linear-gradient(37deg, rgba(29,119,235,1) 0%, rgba(171,49,241,1) 50%, rgba(255,180,49,1) 100%);
 }
 
 /* imnotsure#0876 */
-[user_by_bdfdb*="427853225593667595"],
-[data-user-id*="427853225593667595"] {
+[data-user-id="427853225593667595"] {
 	--user-background: linear-gradient(37deg, rgba(29,119,235,1) 0%, rgba(171,49,241,1) 50%, rgba(255,180,49,1) 100%);
 }
 
 /* Polski#6314 */
-[user_by_bdfdb*="419508419582492672"],
-[data-user-id*="419508419582492672"] {
+[data-user-id="419508419582492672"] {
 	--user-background: #00d3ff;
 }


### PR DESCRIPTION
BDFDB no longer uses `user_by_bdfdb` and now it uses `data-user-id` like powercord
